### PR TITLE
POULPE-528 Set non-serializable filed as transient

### DIFF
--- a/jtalks-common-model/src/main/java/org/jtalks/common/model/entity/User.java
+++ b/jtalks-common-model/src/main/java/org/jtalks/common/model/entity/User.java
@@ -118,7 +118,19 @@ public class User extends Entity implements UserDetails {
 
     private byte[] avatar = new byte[0];
 
-    private List<Group> groups = new ArrayList<Group>();
+    /**
+     *  The {@link org.jtalks.common.model.entity.User} uses serialization for saving own state between
+     *  Tomcat' session restarts. But there is not urgent needs to save state of
+     *  the {@link org.jtalks.common.model.entity.Group}, and moreover serialization of this one
+     *  will pull serialization of even more classes which is undesirable.
+     *
+     *  While we won't serialize full {@link org.jtalks.common.model.entity.Group} entity
+     *  we mark {@link org.jtalks.common.model.entity.User#groups} as transient to avoid the problems
+     *  during serialization of the {@link org.jtalks.common.model.entity.User} and his successors.
+     *
+     *  See more information at <a href="jira.jtalks.org/browse/POULPE-528">JIRA</a>
+     */
+    private transient List<Group> groups = new ArrayList<Group>();
 
     private boolean enabled;
     private Long version;


### PR DESCRIPTION
While User entity implements Serializable through UserDetails and we won't serialize full Group entity we must set non-serializable field 'List<Group> groups' as transient.
(according to issue Poulpe-528 - http://jira.jtalks.org/browse/POULPE-528)
